### PR TITLE
Add parchment-style main menu with settings and scene selection

### DIFF
--- a/src/app/components/clearview/viewport/viewport.component.html
+++ b/src/app/components/clearview/viewport/viewport.component.html
@@ -2,5 +2,5 @@
 <div class="viewport-container">
     <canvas #renderCanvas class="render-canvas"></canvas>
     <app-loading-indicator></app-loading-indicator>
-    <app-pause-menu></app-pause-menu>
+    <app-pause-menu (exit)="onExit()"></app-pause-menu>
 </div>

--- a/src/app/components/clearview/viewport/viewport.component.ts
+++ b/src/app/components/clearview/viewport/viewport.component.ts
@@ -1,9 +1,10 @@
 // src/app/components/clearview/viewport/viewport.component.ts
-import { Component, AfterViewInit, OnDestroy, ViewChild, ElementRef, HostListener, NgZone } from '@angular/core';
+import { Component, AfterViewInit, OnDestroy, ViewChild, ElementRef, HostListener, NgZone, Input, Output, EventEmitter, Type } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { EngineService } from '../../../engine/core/engine.service';
 import { SceneManagerService } from '../../../engine/core/scene-manager.service';
 import { Scene001 } from '../../../engine/scenes/scene001.scene';
+import { BaseScene } from '../../../engine/base/scene';
 import { GuiService } from '../../../engine/core/gui.service';
 import { AssetManagerService } from '../../../engine/core/asset-manager.service';
 import { PauseMenuComponent } from '../../ui/pause-menu/pause-menu.component';
@@ -18,6 +19,8 @@ import { LoadingIndicatorComponent } from '../../ui/loading-indicator/loading-in
 })
 export class ViewportComponent implements AfterViewInit, OnDestroy {
     @ViewChild('renderCanvas', { static: true }) canvasRef!: ElementRef<HTMLCanvasElement>;
+    @Input() sceneType: Type<BaseScene> = Scene001;
+    @Output() exit = new EventEmitter<void>();
     private resizeListener: (() => void) | null = null;
 
     constructor(
@@ -52,7 +55,7 @@ export class ViewportComponent implements AfterViewInit, OnDestroy {
             const canvas = this.canvasRef.nativeElement;
 
             // Load scene (creates fresh engine)
-            await this.sceneManager.loadScene(Scene001, canvas);
+            await this.sceneManager.loadScene(this.sceneType, canvas);
 
             // Initialize GUI
             const scene = this.sceneManager.getCurrentScene();
@@ -87,5 +90,12 @@ export class ViewportComponent implements AfterViewInit, OnDestroy {
                 this.guiService.togglePause();
             });
         }
+    }
+
+    onExit(): void {
+        this.sceneManager.cleanUp();
+        this.engineService.cleanUp();
+        this.guiService.cleanUp();
+        this.exit.emit();
     }
 }

--- a/src/app/components/ui/main-menu/main-menu.component.html
+++ b/src/app/components/ui/main-menu/main-menu.component.html
@@ -1,0 +1,21 @@
+<div class="main-menu-overlay">
+    <main>
+        <div id="parchment"></div>
+        <div id="contain">
+            <h1 class="title">Clearview Demo</h1>
+            <div class="menu-content">
+                <button class="btn-parchment" (click)="start.emit()">Continue</button>
+                <button class="btn-parchment" (click)="openSceneSelector()">Scene Select</button>
+                <button class="btn-parchment" (click)="openSettings()">Settings</button>
+            </div>
+            <app-scene-selector *ngIf="showSceneSelector" (scene)="sceneSelected($event)" (close)="showSceneSelector=false"></app-scene-selector>
+            <app-settings-menu *ngIf="showSettings" (close)="closeSettings()"></app-settings-menu>
+        </div>
+    </main>
+    <svg>
+        <filter id="wavy2">
+            <feTurbulence x="0" y="0" baseFrequency="0.02" numOctaves="5" seed="1" />
+            <feDisplacementMap in="SourceGraphic" scale="20" />
+        </filter>
+    </svg>
+</div>

--- a/src/app/components/ui/main-menu/main-menu.component.less
+++ b/src/app/components/ui/main-menu/main-menu.component.less
@@ -1,0 +1,238 @@
+/* src/app/components/ui/pause-menu/pause-menu.component.less */
+// Custom font declaration
+@font-face {
+    font-family: 'IM Fell English SC';
+    src: url('/assets/fonts/IM Fell English SC/IMFellEnglishSC-Regular.ttf') format('truetype');
+}
+
+:root {
+    --fontSize: calc((1vw + 1vh) * .75);
+}
+
+.main-menu-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.7);
+    backdrop-filter: blur(3px);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+    visibility: hidden;
+    opacity: 0;
+    transition: visibility 0s linear 0.3s, opacity 0.3s;
+
+    &.visible {
+        visibility: visible;
+        opacity: 1;
+        transition: visibility 0s linear 0s, opacity 0.3s;
+    }
+}
+
+main {
+    position: relative;
+    width: 100%;
+    height: auto;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+#parchment {
+    position: absolute;
+    display: flex;
+    width: 450px;
+    max-width: 75%;
+    height: 400px;
+    /* Increased height to accommodate more buttons */
+    /* center page with absolute position */
+    top: 0;
+    left: 50%;
+    transform: translate(-50%, -10%);
+    margin: 2em 0;
+    padding: 4em;
+    box-shadow: 2px 3px 20px black, 0 0 125px #8f5922 inset;
+    background: #fffef0;
+    /* Apply the wavy border effect with SVG filter */
+    filter: url(#wavy2);
+    /* Noise added for a vellum paper effect */
+    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAMAAAAp4XiDAAAAUVBMVEWFhYWDg4N3d3dtbW17e3t1dXWBgYGHh4d5eXlzc3OLi4ubm5uVlZWPj4+NjY19fX2JiYl/f39ra2uRkZGZmZlpaWmXl5dvb29xcXGTk5NnZ2c8TV1mAAAAG3RSTlNAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEAvEOwtAAAFVklEQVR4XpWWB67c2BUFb3g557T/hRo9/WUMZHlgr4Bg8Z4qQgQJlHI4A8SzFVrapvmTF9O7dmYRFZ60YiBhJRCgh1FYhiLAmdvX0CzTOpNE77ME0Zty/nWWzchDtiqrmQDeuv3powQ5ta2eN0FY0InkqDD73lT9c9lEzwUNqgFHs9VQce3TVClFCQrSTfOiYkVJQBmpbq2L6iZavPnAPcoU0dSw0SUTqz/GtrGuXfbyyBniKykOWQWGqwwMA7QiYAxi+IlPdqo+hYHnUt5ZPfnsHJyNiDtnpJyayNBkF6cWoYGAMY92U2hXHF/C1M8uP/ZtYdiuj26UdAdQQSXQErwSOMzt/XWRWAz5GuSBIkwG1H3FabJ2OsUOUhGC6tK4EMtJO0ttC6IBD3kM0ve0tJwMdSfjZo+EEISaeTr9P3wYrGjXqyC1krcKdhMpxEnt5JetoulscpyzhXN5FRpuPHvbeQaKxFAEB6EN+cYN6xD7RYGpXpNndMmZgM5Dcs3YSNFDHUo2LGfZuukSWyUYirJAdYbF3MfqEKmjM+I2EfhA94iG3L7uKrR+GdWD73ydlIB+6hgref1QTlmgmbM3/LeX5GI1Ux1RWpgxpLuZ2+I+IjzZ8wqE4nilvQdkUdfhzI5QDWy+kw5Wgg2pGpeEVeCCA7b85BO3F9DzxB3cdqvBzWcmzbyMiqhzuYqtHRVG2y4x+KOlnyqla8AoWWpuBoYRxzXrfKuILl6SfiWCbjxoZJUaCBj1CjH7GIaDbc9kqBY3W/Rgjda1iqQcOJu2WW+76pZC9QG7M00dffe9hNnseupFL53r8F7YHSwJWUKP2q+k7RdsxyOB11n0xtOvnW4irMMFNV4H0uqwS5ExsmP9AxbDTc9JwgneAT5vTiUSm1E7BSflSt3bfa1tv8Di3R8n3Af7MNWzs49hmauE2wP+ttrq+AsWpFG2awvsuOqbipWHgtuvuaAE+A1Z/7gC9hesnr+7wqCwG8c5yAg3AL1fm8T9AZtp/bbJGwl1pNrE7RuOX7PeMRUERVaPpEs+yqeoSmuOlokqw49pgomjLeh7icHNlG19yjs6XXOMedYm5xH2YxpV2tc0Ro2jJfxC50ApuxGob7lMsxfTbeUv07TyYxpeLucEH1gNd4IKH2LAg5TdVhlCafZvpskfncCfx8pOhJzd76bJWeYFnFciwcYfubRc12Ip/ppIhA1/mSZ/RxjFDrJC5xifFjJpY2Xl5zXdguFqYyTR1zSp1Y9p+tktDYYSNflcxI0iyO4TPBdlRcpeqjK/piF5bklq77VSEaA+z8qmJTFzIWiitbnzR794USKBUaT0NTEsVjZqLaFVqJoPN9ODG70IPbfBHKK+/q/AWR0tJzYHRULOa4MP+W/HfGadZUbfw177G7j/OGbIs8TahLyynl4X4RinF793Oz+BU0saXtUHrVBFT/DnA3ctNPoGbs4hRIjTok8i+algT1lTHi4SxFvONKNrgQFAq2/gFnWMXgwffgYMJpiKYkmW3tTg3ZQ9Jq+f8XN+A5eeUKHWvJWJ2sgJ1Sop+wwhqFVijqWaJhwtD8MNlSBeWNNWTa5Z5kPZw5+LbVT99wqTdx29lMUH4OIG/D86ruKEauBjvH5xy6um/Sfj7ei6UUVk4AIl3MyD4MSSTOFgSwsH/QJWaQ5as7ZcmgBZkzjjU1UrQ74ci1gWBCSGHtuV1H2mhSnO3Wp/3fEV5a+4wz//6qy8JxjZsmxxy5+4w9CDNJY09T072iKG0EnOS0arEYgXqYnXcYHwjTtUNAcMelOd4xpkoqiTYICWFq0JSiPfPDQdnt+4/wuqcXY47QILbgAAAABJRU5ErkJggg==);
+}
+
+#contain {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 450px;
+    max-width: 75%;
+    height: 400px;
+    /* Increased height to match parchment */
+    margin: 0 auto;
+    padding: 2em;
+    z-index: 5;
+}
+
+.title {
+    font-family: 'IM Fell English SC', serif;
+    font-weight: normal;
+    font-size: 2.4rem;
+    letter-spacing: 0.03em;
+    color: #7F3300;
+    text-align: center;
+    margin-bottom: 1.2rem;
+    /* Reduced to accommodate more buttons */
+
+    /* Add decorative lines on either side of the title */
+    position: relative;
+
+    &::before,
+    &::after {
+        content: '';
+        position: absolute;
+        height: 1px;
+        background: rgba(127, 51, 0, 0.3);
+        width: 30px;
+        top: 50%;
+    }
+
+    &::before {
+        right: 110%;
+    }
+
+    &::after {
+        left: 110%;
+    }
+}
+
+.menu-content {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-top: 1rem;
+    /* Reduced to accommodate more buttons */
+    position: relative;
+
+    /* Add decorative separator between title and buttons */
+    &::before {
+        content: '✦';
+        color: rgba(127, 51, 0, 0.5);
+        font-size: 1rem;
+        margin-bottom: 0.5rem;
+    }
+}
+
+.btn-parchment {
+    position: relative;
+    background: transparent;
+    border: none;
+    color: #5a2800;
+    font-family: 'IM Fell English SC', serif;
+    font-size: 1.6rem;
+    letter-spacing: 0.06em;
+    padding: 10px 0;
+    /* Vertical padding only */
+    margin: 8px 0;
+    /* Reduced spacing between buttons */
+    cursor: pointer;
+    transition: color 0.3s ease;
+    min-width: 200px;
+    text-align: center;
+    overflow: hidden;
+
+    /* Text shadow to give slight depth to the writing */
+    text-shadow: 0px 1px 1px rgba(255, 250, 230, 0.5);
+
+    /* Ink-like effect on the text */
+    -webkit-font-smoothing: antialiased;
+
+    /* Subtle underline effect - starts smaller than text */
+    &::after {
+        content: '';
+        position: absolute;
+        left: 50%;
+        /* Start more centered */
+        bottom: 4px;
+        width: 0%;
+        /* Start shorter than text */
+        height: 1px;
+        background: rgba(90, 40, 0, 0.4);
+        transition: all 0.4s ease;
+        /* Slower expansion */
+        transform-origin: center;
+    }
+
+    /* Hover effects - no vertical movement */
+    &:hover {
+        color: #8a3500;
+
+        &::before {
+            opacity: 0.06;
+        }
+
+        &::after {
+            width: 40%;
+            /* Expands, but still shorter than text */
+            left: 30%;
+            background: rgba(138, 53, 0, 0.6);
+        }
+    }
+
+    /* Subtle highlight area behind text on hover */
+    &::before {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: radial-gradient(ellipse at center,
+                rgba(255, 249, 215, 0.7) 0%,
+                rgba(255, 249, 215, 0) 70%);
+        opacity: 0;
+        transition: opacity 0.3s ease;
+        z-index: -1;
+    }
+
+    /* Active/click state - removed vertical movement, just subtle color change */
+    &:active {
+        color: #7F3300;
+
+        &::after {
+            height: 1px;
+            width: 40%;
+            left: 30%;
+            background: rgba(127, 51, 0, 0.8);
+        }
+    }
+}
+
+/* Add subtle decorative elements between buttons */
+.btn-parchment+.btn-parchment {
+    position: relative;
+
+    &::before {
+        content: '';
+        position: absolute;
+        top: -5px;
+        left: 50%;
+        transform: translateX(-50%);
+        width: 4px;
+        height: 4px;
+        border-radius: 50%;
+        background-color: rgba(90, 40, 0, 0.15);
+    }
+}
+
+/* Hide SVG */
+svg {
+    position: absolute;
+    width: 0;
+    height: 0;
+    overflow: hidden;
+}

--- a/src/app/components/ui/main-menu/main-menu.component.ts
+++ b/src/app/components/ui/main-menu/main-menu.component.ts
@@ -1,0 +1,37 @@
+import { Component, EventEmitter, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SettingsMenuComponent } from '../settings-menu/settings-menu.component';
+import { SceneSelectorComponent } from '../scene-selector/scene-selector.component';
+import { Type } from '@angular/core';
+
+@Component({
+    selector: 'app-main-menu',
+    standalone: true,
+    imports: [CommonModule, SettingsMenuComponent, SceneSelectorComponent],
+    templateUrl: './main-menu.component.html',
+    styleUrls: ['./main-menu.component.less']
+})
+export class MainMenuComponent {
+    @Output() start = new EventEmitter<void>();
+    @Output() scene = new EventEmitter<Type<any>>();
+
+    showSettings = false;
+    showSceneSelector = false;
+
+    openSettings(): void {
+        this.showSettings = true;
+    }
+
+    openSceneSelector(): void {
+        this.showSceneSelector = true;
+    }
+
+    closeSettings(): void {
+        this.showSettings = false;
+    }
+
+    sceneSelected(type: Type<any>): void {
+        this.scene.emit(type);
+        this.showSceneSelector = false;
+    }
+}

--- a/src/app/components/ui/pause-menu/pause-menu.component.html
+++ b/src/app/components/ui/pause-menu/pause-menu.component.html
@@ -7,7 +7,7 @@
             <div class="menu-content">
                 <button class="btn-parchment" (click)="resumeGame()">Resume</button>
                 <button class="btn-parchment" (click)="resumeGame()">Settings</button>
-                <button class="btn-parchment" (click)="resumeGame()">Main Menu</button>
+                <button class="btn-parchment" (click)="backToMainMenu()">Main Menu</button>
             </div>
         </div>
     </main>

--- a/src/app/components/ui/pause-menu/pause-menu.component.ts
+++ b/src/app/components/ui/pause-menu/pause-menu.component.ts
@@ -1,5 +1,5 @@
 // src/app/components/ui/pause-menu/pause-menu.component.ts
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnInit, OnDestroy, Output, EventEmitter } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { GuiService } from '../../../engine/core/gui.service';
 import { Subscription } from 'rxjs';
@@ -14,6 +14,7 @@ import { Subscription } from 'rxjs';
 export class PauseMenuComponent implements OnInit, OnDestroy {
     isVisible = false;
     private subscription: Subscription | null = null;
+    @Output() exit = new EventEmitter<void>();
 
     constructor(private guiService: GuiService) { }
 
@@ -32,5 +33,10 @@ export class PauseMenuComponent implements OnInit, OnDestroy {
     resumeGame(): void {
         // Use the same method that the ESC key uses
         this.guiService.setPaused(false);
+    }
+
+    backToMainMenu(): void {
+        this.guiService.setPaused(false);
+        this.exit.emit();
     }
 }

--- a/src/app/components/ui/scene-selector/scene-selector.component.html
+++ b/src/app/components/ui/scene-selector/scene-selector.component.html
@@ -1,0 +1,20 @@
+<div class="selector-overlay">
+    <main>
+        <div id="parchment"></div>
+        <div id="contain">
+            <h2 class="title">Select Scene</h2>
+            <div class="menu-content">
+                <button class="btn-parchment" *ngFor="let s of scenes" (click)="selectScene(s)">
+                    {{ s.name }}
+                </button>
+                <button class="btn-parchment" (click)="closeDialog()">Back</button>
+            </div>
+        </div>
+    </main>
+    <svg>
+        <filter id="wavy2">
+            <feTurbulence x="0" y="0" baseFrequency="0.02" numOctaves="5" seed="1" />
+            <feDisplacementMap in="SourceGraphic" scale="20" />
+        </filter>
+    </svg>
+</div>

--- a/src/app/components/ui/scene-selector/scene-selector.component.less
+++ b/src/app/components/ui/scene-selector/scene-selector.component.less
@@ -1,0 +1,238 @@
+/* src/app/components/ui/pause-menu/pause-menu.component.less */
+// Custom font declaration
+@font-face {
+    font-family: 'IM Fell English SC';
+    src: url('/assets/fonts/IM Fell English SC/IMFellEnglishSC-Regular.ttf') format('truetype');
+}
+
+:root {
+    --fontSize: calc((1vw + 1vh) * .75);
+}
+
+.selector-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.7);
+    backdrop-filter: blur(3px);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+    visibility: hidden;
+    opacity: 0;
+    transition: visibility 0s linear 0.3s, opacity 0.3s;
+
+    &.visible {
+        visibility: visible;
+        opacity: 1;
+        transition: visibility 0s linear 0s, opacity 0.3s;
+    }
+}
+
+main {
+    position: relative;
+    width: 100%;
+    height: auto;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+#parchment {
+    position: absolute;
+    display: flex;
+    width: 450px;
+    max-width: 75%;
+    height: 400px;
+    /* Increased height to accommodate more buttons */
+    /* center page with absolute position */
+    top: 0;
+    left: 50%;
+    transform: translate(-50%, -10%);
+    margin: 2em 0;
+    padding: 4em;
+    box-shadow: 2px 3px 20px black, 0 0 125px #8f5922 inset;
+    background: #fffef0;
+    /* Apply the wavy border effect with SVG filter */
+    filter: url(#wavy2);
+    /* Noise added for a vellum paper effect */
+    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAMAAAAp4XiDAAAAUVBMVEWFhYWDg4N3d3dtbW17e3t1dXWBgYGHh4d5eXlzc3OLi4ubm5uVlZWPj4+NjY19fX2JiYl/f39ra2uRkZGZmZlpaWmXl5dvb29xcXGTk5NnZ2c8TV1mAAAAG3RSTlNAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEAvEOwtAAAFVklEQVR4XpWWB67c2BUFb3g557T/hRo9/WUMZHlgr4Bg8Z4qQgQJlHI4A8SzFVrapvmTF9O7dmYRFZ60YiBhJRCgh1FYhiLAmdvX0CzTOpNE77ME0Zty/nWWzchDtiqrmQDeuv3powQ5ta2eN0FY0InkqDD73lT9c9lEzwUNqgFHs9VQce3TVClFCQrSTfOiYkVJQBmpbq2L6iZavPnAPcoU0dSw0SUTqz/GtrGuXfbyyBniKykOWQWGqwwMA7QiYAxi+IlPdqo+hYHnUt5ZPfnsHJyNiDtnpJyayNBkF6cWoYGAMY92U2hXHF/C1M8uP/ZtYdiuj26UdAdQQSXQErwSOMzt/XWRWAz5GuSBIkwG1H3FabJ2OsUOUhGC6tK4EMtJO0ttC6IBD3kM0ve0tJwMdSfjZo+EEISaeTr9P3wYrGjXqyC1krcKdhMpxEnt5JetoulscpyzhXN5FRpuPHvbeQaKxFAEB6EN+cYN6xD7RYGpXpNndMmZgM5Dcs3YSNFDHUo2LGfZuukSWyUYirJAdYbF3MfqEKmjM+I2EfhA94iG3L7uKrR+GdWD73ydlIB+6hgref1QTlmgmbM3/LeX5GI1Ux1RWpgxpLuZ2+I+IjzZ8wqE4nilvQdkUdfhzI5QDWy+kw5Wgg2pGpeEVeCCA7b85BO3F9DzxB3cdqvBzWcmzbyMiqhzuYqtHRVG2y4x+KOlnyqla8AoWWpuBoYRxzXrfKuILl6SfiWCbjxoZJUaCBj1CjH7GIaDbc9kqBY3W/Rgjda1iqQcOJu2WW+76pZC9QG7M00dffe9hNnseupFL53r8F7YHSwJWUKP2q+k7RdsxyOB11n0xtOvnW4irMMFNV4H0uqwS5ExsmP9AxbDTc9JwgneAT5vTiUSm1E7BSflSt3bfa1tv8Di3R8n3Af7MNWzs49hmauE2wP+ttrq+AsWpFG2awvsuOqbipWHgtuvuaAE+A1Z/7gC9hesnr+7wqCwG8c5yAg3AL1fm8T9AZtp/bbJGwl1pNrE7RuOX7PeMRUERVaPpEs+yqeoSmuOlokqw49pgomjLeh7icHNlG19yjs6XXOMedYm5xH2YxpV2tc0Ro2jJfxC50ApuxGob7lMsxfTbeUv07TyYxpeLucEH1gNd4IKH2LAg5TdVhlCafZvpskfncCfx8pOhJzd76bJWeYFnFciwcYfubRc12Ip/ppIhA1/mSZ/RxjFDrJC5xifFjJpY2Xl5zXdguFqYyTR1zSp1Y9p+tktDYYSNflcxI0iyO4TPBdlRcpeqjK/piF5bklq77VSEaA+z8qmJTFzIWiitbnzR794USKBUaT0NTEsVjZqLaFVqJoPN9ODG70IPbfBHKK+/q/AWR0tJzYHRULOa4MP+W/HfGadZUbfw177G7j/OGbIs8TahLyynl4X4RinF793Oz+BU0saXtUHrVBFT/DnA3ctNPoGbs4hRIjTok8i+algT1lTHi4SxFvONKNrgQFAq2/gFnWMXgwffgYMJpiKYkmW3tTg3ZQ9Jq+f8XN+A5eeUKHWvJWJ2sgJ1Sop+wwhqFVijqWaJhwtD8MNlSBeWNNWTa5Z5kPZw5+LbVT99wqTdx29lMUH4OIG/D86ruKEauBjvH5xy6um/Sfj7ei6UUVk4AIl3MyD4MSSTOFgSwsH/QJWaQ5as7ZcmgBZkzjjU1UrQ74ci1gWBCSGHtuV1H2mhSnO3Wp/3fEV5a+4wz//6qy8JxjZsmxxy5+4w9CDNJY09T072iKG0EnOS0arEYgXqYnXcYHwjTtUNAcMelOd4xpkoqiTYICWFq0JSiPfPDQdnt+4/wuqcXY47QILbgAAAABJRU5ErkJggg==);
+}
+
+#contain {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 450px;
+    max-width: 75%;
+    height: 400px;
+    /* Increased height to match parchment */
+    margin: 0 auto;
+    padding: 2em;
+    z-index: 5;
+}
+
+.title {
+    font-family: 'IM Fell English SC', serif;
+    font-weight: normal;
+    font-size: 2.4rem;
+    letter-spacing: 0.03em;
+    color: #7F3300;
+    text-align: center;
+    margin-bottom: 1.2rem;
+    /* Reduced to accommodate more buttons */
+
+    /* Add decorative lines on either side of the title */
+    position: relative;
+
+    &::before,
+    &::after {
+        content: '';
+        position: absolute;
+        height: 1px;
+        background: rgba(127, 51, 0, 0.3);
+        width: 30px;
+        top: 50%;
+    }
+
+    &::before {
+        right: 110%;
+    }
+
+    &::after {
+        left: 110%;
+    }
+}
+
+.menu-content {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-top: 1rem;
+    /* Reduced to accommodate more buttons */
+    position: relative;
+
+    /* Add decorative separator between title and buttons */
+    &::before {
+        content: '✦';
+        color: rgba(127, 51, 0, 0.5);
+        font-size: 1rem;
+        margin-bottom: 0.5rem;
+    }
+}
+
+.btn-parchment {
+    position: relative;
+    background: transparent;
+    border: none;
+    color: #5a2800;
+    font-family: 'IM Fell English SC', serif;
+    font-size: 1.6rem;
+    letter-spacing: 0.06em;
+    padding: 10px 0;
+    /* Vertical padding only */
+    margin: 8px 0;
+    /* Reduced spacing between buttons */
+    cursor: pointer;
+    transition: color 0.3s ease;
+    min-width: 200px;
+    text-align: center;
+    overflow: hidden;
+
+    /* Text shadow to give slight depth to the writing */
+    text-shadow: 0px 1px 1px rgba(255, 250, 230, 0.5);
+
+    /* Ink-like effect on the text */
+    -webkit-font-smoothing: antialiased;
+
+    /* Subtle underline effect - starts smaller than text */
+    &::after {
+        content: '';
+        position: absolute;
+        left: 50%;
+        /* Start more centered */
+        bottom: 4px;
+        width: 0%;
+        /* Start shorter than text */
+        height: 1px;
+        background: rgba(90, 40, 0, 0.4);
+        transition: all 0.4s ease;
+        /* Slower expansion */
+        transform-origin: center;
+    }
+
+    /* Hover effects - no vertical movement */
+    &:hover {
+        color: #8a3500;
+
+        &::before {
+            opacity: 0.06;
+        }
+
+        &::after {
+            width: 40%;
+            /* Expands, but still shorter than text */
+            left: 30%;
+            background: rgba(138, 53, 0, 0.6);
+        }
+    }
+
+    /* Subtle highlight area behind text on hover */
+    &::before {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: radial-gradient(ellipse at center,
+                rgba(255, 249, 215, 0.7) 0%,
+                rgba(255, 249, 215, 0) 70%);
+        opacity: 0;
+        transition: opacity 0.3s ease;
+        z-index: -1;
+    }
+
+    /* Active/click state - removed vertical movement, just subtle color change */
+    &:active {
+        color: #7F3300;
+
+        &::after {
+            height: 1px;
+            width: 40%;
+            left: 30%;
+            background: rgba(127, 51, 0, 0.8);
+        }
+    }
+}
+
+/* Add subtle decorative elements between buttons */
+.btn-parchment+.btn-parchment {
+    position: relative;
+
+    &::before {
+        content: '';
+        position: absolute;
+        top: -5px;
+        left: 50%;
+        transform: translateX(-50%);
+        width: 4px;
+        height: 4px;
+        border-radius: 50%;
+        background-color: rgba(90, 40, 0, 0.15);
+    }
+}
+
+/* Hide SVG */
+svg {
+    position: absolute;
+    width: 0;
+    height: 0;
+    overflow: hidden;
+}

--- a/src/app/components/ui/scene-selector/scene-selector.component.ts
+++ b/src/app/components/ui/scene-selector/scene-selector.component.ts
@@ -1,0 +1,31 @@
+import { Component, EventEmitter, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Scene001 } from '../../../engine/scenes/scene001.scene';
+import { Type } from '@angular/core';
+
+interface SceneOption { name: string; type: Type<any>; }
+
+@Component({
+    selector: 'app-scene-selector',
+    standalone: true,
+    imports: [CommonModule],
+    templateUrl: './scene-selector.component.html',
+    styleUrls: ['./scene-selector.component.less']
+})
+export class SceneSelectorComponent {
+    @Output() scene = new EventEmitter<Type<any>>();
+    @Output() close = new EventEmitter<void>();
+
+    scenes: SceneOption[] = [
+        { name: 'Scene 1', type: Scene001 }
+    ];
+
+    selectScene(option: SceneOption): void {
+        this.scene.emit(option.type);
+        this.close.emit();
+    }
+
+    closeDialog(): void {
+        this.close.emit();
+    }
+}

--- a/src/app/components/ui/settings-menu/settings-menu.component.html
+++ b/src/app/components/ui/settings-menu/settings-menu.component.html
@@ -1,0 +1,21 @@
+<div class="settings-overlay">
+    <main>
+        <div id="parchment"></div>
+        <div id="contain">
+            <h2 class="title">Settings</h2>
+            <div class="menu-content">
+                <label class="volume-control">
+                    Volume
+                    <input type="range" min="0" max="1" step="0.01" [(ngModel)]="volume" (input)="onVolumeChange()" />
+                </label>
+                <button class="btn-parchment" (click)="closeDialog()">Close</button>
+            </div>
+        </div>
+    </main>
+    <svg>
+        <filter id="wavy2">
+            <feTurbulence x="0" y="0" baseFrequency="0.02" numOctaves="5" seed="1" />
+            <feDisplacementMap in="SourceGraphic" scale="20" />
+        </filter>
+    </svg>
+</div>

--- a/src/app/components/ui/settings-menu/settings-menu.component.less
+++ b/src/app/components/ui/settings-menu/settings-menu.component.less
@@ -1,0 +1,238 @@
+/* src/app/components/ui/pause-menu/pause-menu.component.less */
+// Custom font declaration
+@font-face {
+    font-family: 'IM Fell English SC';
+    src: url('/assets/fonts/IM Fell English SC/IMFellEnglishSC-Regular.ttf') format('truetype');
+}
+
+:root {
+    --fontSize: calc((1vw + 1vh) * .75);
+}
+
+.settings-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.7);
+    backdrop-filter: blur(3px);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+    visibility: hidden;
+    opacity: 0;
+    transition: visibility 0s linear 0.3s, opacity 0.3s;
+
+    &.visible {
+        visibility: visible;
+        opacity: 1;
+        transition: visibility 0s linear 0s, opacity 0.3s;
+    }
+}
+
+main {
+    position: relative;
+    width: 100%;
+    height: auto;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+#parchment {
+    position: absolute;
+    display: flex;
+    width: 450px;
+    max-width: 75%;
+    height: 400px;
+    /* Increased height to accommodate more buttons */
+    /* center page with absolute position */
+    top: 0;
+    left: 50%;
+    transform: translate(-50%, -10%);
+    margin: 2em 0;
+    padding: 4em;
+    box-shadow: 2px 3px 20px black, 0 0 125px #8f5922 inset;
+    background: #fffef0;
+    /* Apply the wavy border effect with SVG filter */
+    filter: url(#wavy2);
+    /* Noise added for a vellum paper effect */
+    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAMAAAAp4XiDAAAAUVBMVEWFhYWDg4N3d3dtbW17e3t1dXWBgYGHh4d5eXlzc3OLi4ubm5uVlZWPj4+NjY19fX2JiYl/f39ra2uRkZGZmZlpaWmXl5dvb29xcXGTk5NnZ2c8TV1mAAAAG3RSTlNAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEAvEOwtAAAFVklEQVR4XpWWB67c2BUFb3g557T/hRo9/WUMZHlgr4Bg8Z4qQgQJlHI4A8SzFVrapvmTF9O7dmYRFZ60YiBhJRCgh1FYhiLAmdvX0CzTOpNE77ME0Zty/nWWzchDtiqrmQDeuv3powQ5ta2eN0FY0InkqDD73lT9c9lEzwUNqgFHs9VQce3TVClFCQrSTfOiYkVJQBmpbq2L6iZavPnAPcoU0dSw0SUTqz/GtrGuXfbyyBniKykOWQWGqwwMA7QiYAxi+IlPdqo+hYHnUt5ZPfnsHJyNiDtnpJyayNBkF6cWoYGAMY92U2hXHF/C1M8uP/ZtYdiuj26UdAdQQSXQErwSOMzt/XWRWAz5GuSBIkwG1H3FabJ2OsUOUhGC6tK4EMtJO0ttC6IBD3kM0ve0tJwMdSfjZo+EEISaeTr9P3wYrGjXqyC1krcKdhMpxEnt5JetoulscpyzhXN5FRpuPHvbeQaKxFAEB6EN+cYN6xD7RYGpXpNndMmZgM5Dcs3YSNFDHUo2LGfZuukSWyUYirJAdYbF3MfqEKmjM+I2EfhA94iG3L7uKrR+GdWD73ydlIB+6hgref1QTlmgmbM3/LeX5GI1Ux1RWpgxpLuZ2+I+IjzZ8wqE4nilvQdkUdfhzI5QDWy+kw5Wgg2pGpeEVeCCA7b85BO3F9DzxB3cdqvBzWcmzbyMiqhzuYqtHRVG2y4x+KOlnyqla8AoWWpuBoYRxzXrfKuILl6SfiWCbjxoZJUaCBj1CjH7GIaDbc9kqBY3W/Rgjda1iqQcOJu2WW+76pZC9QG7M00dffe9hNnseupFL53r8F7YHSwJWUKP2q+k7RdsxyOB11n0xtOvnW4irMMFNV4H0uqwS5ExsmP9AxbDTc9JwgneAT5vTiUSm1E7BSflSt3bfa1tv8Di3R8n3Af7MNWzs49hmauE2wP+ttrq+AsWpFG2awvsuOqbipWHgtuvuaAE+A1Z/7gC9hesnr+7wqCwG8c5yAg3AL1fm8T9AZtp/bbJGwl1pNrE7RuOX7PeMRUERVaPpEs+yqeoSmuOlokqw49pgomjLeh7icHNlG19yjs6XXOMedYm5xH2YxpV2tc0Ro2jJfxC50ApuxGob7lMsxfTbeUv07TyYxpeLucEH1gNd4IKH2LAg5TdVhlCafZvpskfncCfx8pOhJzd76bJWeYFnFciwcYfubRc12Ip/ppIhA1/mSZ/RxjFDrJC5xifFjJpY2Xl5zXdguFqYyTR1zSp1Y9p+tktDYYSNflcxI0iyO4TPBdlRcpeqjK/piF5bklq77VSEaA+z8qmJTFzIWiitbnzR794USKBUaT0NTEsVjZqLaFVqJoPN9ODG70IPbfBHKK+/q/AWR0tJzYHRULOa4MP+W/HfGadZUbfw177G7j/OGbIs8TahLyynl4X4RinF793Oz+BU0saXtUHrVBFT/DnA3ctNPoGbs4hRIjTok8i+algT1lTHi4SxFvONKNrgQFAq2/gFnWMXgwffgYMJpiKYkmW3tTg3ZQ9Jq+f8XN+A5eeUKHWvJWJ2sgJ1Sop+wwhqFVijqWaJhwtD8MNlSBeWNNWTa5Z5kPZw5+LbVT99wqTdx29lMUH4OIG/D86ruKEauBjvH5xy6um/Sfj7ei6UUVk4AIl3MyD4MSSTOFgSwsH/QJWaQ5as7ZcmgBZkzjjU1UrQ74ci1gWBCSGHtuV1H2mhSnO3Wp/3fEV5a+4wz//6qy8JxjZsmxxy5+4w9CDNJY09T072iKG0EnOS0arEYgXqYnXcYHwjTtUNAcMelOd4xpkoqiTYICWFq0JSiPfPDQdnt+4/wuqcXY47QILbgAAAABJRU5ErkJggg==);
+}
+
+#contain {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 450px;
+    max-width: 75%;
+    height: 400px;
+    /* Increased height to match parchment */
+    margin: 0 auto;
+    padding: 2em;
+    z-index: 5;
+}
+
+.title {
+    font-family: 'IM Fell English SC', serif;
+    font-weight: normal;
+    font-size: 2.4rem;
+    letter-spacing: 0.03em;
+    color: #7F3300;
+    text-align: center;
+    margin-bottom: 1.2rem;
+    /* Reduced to accommodate more buttons */
+
+    /* Add decorative lines on either side of the title */
+    position: relative;
+
+    &::before,
+    &::after {
+        content: '';
+        position: absolute;
+        height: 1px;
+        background: rgba(127, 51, 0, 0.3);
+        width: 30px;
+        top: 50%;
+    }
+
+    &::before {
+        right: 110%;
+    }
+
+    &::after {
+        left: 110%;
+    }
+}
+
+.menu-content {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-top: 1rem;
+    /* Reduced to accommodate more buttons */
+    position: relative;
+
+    /* Add decorative separator between title and buttons */
+    &::before {
+        content: '✦';
+        color: rgba(127, 51, 0, 0.5);
+        font-size: 1rem;
+        margin-bottom: 0.5rem;
+    }
+}
+
+.btn-parchment {
+    position: relative;
+    background: transparent;
+    border: none;
+    color: #5a2800;
+    font-family: 'IM Fell English SC', serif;
+    font-size: 1.6rem;
+    letter-spacing: 0.06em;
+    padding: 10px 0;
+    /* Vertical padding only */
+    margin: 8px 0;
+    /* Reduced spacing between buttons */
+    cursor: pointer;
+    transition: color 0.3s ease;
+    min-width: 200px;
+    text-align: center;
+    overflow: hidden;
+
+    /* Text shadow to give slight depth to the writing */
+    text-shadow: 0px 1px 1px rgba(255, 250, 230, 0.5);
+
+    /* Ink-like effect on the text */
+    -webkit-font-smoothing: antialiased;
+
+    /* Subtle underline effect - starts smaller than text */
+    &::after {
+        content: '';
+        position: absolute;
+        left: 50%;
+        /* Start more centered */
+        bottom: 4px;
+        width: 0%;
+        /* Start shorter than text */
+        height: 1px;
+        background: rgba(90, 40, 0, 0.4);
+        transition: all 0.4s ease;
+        /* Slower expansion */
+        transform-origin: center;
+    }
+
+    /* Hover effects - no vertical movement */
+    &:hover {
+        color: #8a3500;
+
+        &::before {
+            opacity: 0.06;
+        }
+
+        &::after {
+            width: 40%;
+            /* Expands, but still shorter than text */
+            left: 30%;
+            background: rgba(138, 53, 0, 0.6);
+        }
+    }
+
+    /* Subtle highlight area behind text on hover */
+    &::before {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: radial-gradient(ellipse at center,
+                rgba(255, 249, 215, 0.7) 0%,
+                rgba(255, 249, 215, 0) 70%);
+        opacity: 0;
+        transition: opacity 0.3s ease;
+        z-index: -1;
+    }
+
+    /* Active/click state - removed vertical movement, just subtle color change */
+    &:active {
+        color: #7F3300;
+
+        &::after {
+            height: 1px;
+            width: 40%;
+            left: 30%;
+            background: rgba(127, 51, 0, 0.8);
+        }
+    }
+}
+
+/* Add subtle decorative elements between buttons */
+.btn-parchment+.btn-parchment {
+    position: relative;
+
+    &::before {
+        content: '';
+        position: absolute;
+        top: -5px;
+        left: 50%;
+        transform: translateX(-50%);
+        width: 4px;
+        height: 4px;
+        border-radius: 50%;
+        background-color: rgba(90, 40, 0, 0.15);
+    }
+}
+
+/* Hide SVG */
+svg {
+    position: absolute;
+    width: 0;
+    height: 0;
+    overflow: hidden;
+}

--- a/src/app/components/ui/settings-menu/settings-menu.component.ts
+++ b/src/app/components/ui/settings-menu/settings-menu.component.ts
@@ -1,0 +1,32 @@
+import { Component, EventEmitter, OnInit, OnDestroy, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { SettingsService } from '../../../services/settings.service';
+
+@Component({
+    selector: 'app-settings-menu',
+    standalone: true,
+    imports: [CommonModule, FormsModule],
+    templateUrl: './settings-menu.component.html',
+    styleUrls: ['./settings-menu.component.less']
+})
+export class SettingsMenuComponent implements OnInit, OnDestroy {
+    @Output() close = new EventEmitter<void>();
+    volume = 1;
+
+    constructor(private settings: SettingsService) {}
+
+    ngOnInit(): void {
+        this.volume = this.settings.currentAudioSettings.volume;
+    }
+
+    ngOnDestroy(): void {}
+
+    onVolumeChange(): void {
+        this.settings.setVolume(this.volume);
+    }
+
+    closeDialog(): void {
+        this.close.emit();
+    }
+}

--- a/src/app/pages/demo/clearview/clearview.component.html
+++ b/src/app/pages/demo/clearview/clearview.component.html
@@ -1,2 +1,3 @@
 <!-- src/app/pages/demo/clearview/clearview.component.html -->
-<clearview-viewport></clearview-viewport>
+<app-main-menu *ngIf="showMenu" (start)="startScene()" (scene)="selectScene($event)"></app-main-menu>
+<clearview-viewport *ngIf="!showMenu" [sceneType]="sceneType" (exit)="returnToMenu()"></clearview-viewport>

--- a/src/app/pages/demo/clearview/clearview.component.ts
+++ b/src/app/pages/demo/clearview/clearview.component.ts
@@ -1,13 +1,29 @@
 // src/app/pages/demo/clearview/clearview.component.ts
-import { Component } from '@angular/core';
+import { Component, Type } from '@angular/core';
 import { ViewportComponent } from '../../../components/clearview/viewport/viewport.component';
+import { MainMenuComponent } from '../../../components/ui/main-menu/main-menu.component';
+import { Scene001 } from '../../../engine/scenes/scene001.scene';
+import { BaseScene } from '../../../engine/base/scene';
 
 @Component({
     selector: 'app-clearview',
-    imports: [ViewportComponent],
+    imports: [ViewportComponent, MainMenuComponent],
     templateUrl: './clearview.component.html',
     styleUrls: ['./clearview.component.less']
 })
 export class ClearviewComponent {
+    showMenu = true;
+    sceneType: Type<BaseScene> = Scene001;
 
+    startScene(): void {
+        this.showMenu = false;
+    }
+
+    selectScene(type: Type<BaseScene>): void {
+        this.sceneType = type;
+    }
+
+    returnToMenu(): void {
+        this.showMenu = true;
+    }
 }

--- a/src/app/services/settings.service.ts
+++ b/src/app/services/settings.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+export interface AudioSettings {
+    volume: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class SettingsService {
+    private audioSettingsSubject = new BehaviorSubject<AudioSettings>({ volume: 1 });
+
+    get audioSettings$() {
+        return this.audioSettingsSubject.asObservable();
+    }
+
+    setVolume(volume: number): void {
+        const settings = this.audioSettingsSubject.getValue();
+        this.audioSettingsSubject.next({ ...settings, volume });
+    }
+
+    get currentAudioSettings(): AudioSettings {
+        return this.audioSettingsSubject.getValue();
+    }
+}


### PR DESCRIPTION
## Summary
- implement `SettingsService` to store audio volume
- add new main menu with buttons for Continue, Scene Select and Settings
- implement scene selector and settings dialogs styled like pause menu
- update Clearview page to show main menu before viewport loads
- allow viewport to load a selected scene and emit exit events
- let pause menu return to main menu and clean up the scene

## Testing
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861f70b969c8322a6005ac54163258f