### PR TITLE
Add save game service and integrate cleanup

### DIFF
--- a/src/app/components/clearview/viewport/viewport.component.ts
+++ b/src/app/components/clearview/viewport/viewport.component.ts
@@ -6,6 +6,7 @@ import { SceneManagerService } from '../../../engine/core/scene-manager.service'
 import { Scene001 } from '../../../engine/scenes/scene001.scene';
 import { GuiService } from '../../../engine/core/gui.service';
 import { AssetManagerService } from '../../../engine/core/asset-manager.service';
+import { SaveGameService } from '../../../engine/core/save-game.service';
 import { PauseMenuComponent } from '../../ui/pause-menu/pause-menu.component';
 import { LoadingIndicatorComponent } from '../../ui/loading-indicator/loading-indicator.component';
 
@@ -25,7 +26,8 @@ export class ViewportComponent implements AfterViewInit, OnDestroy {
         private engineService: EngineService,
         private sceneManager: SceneManagerService,
         private guiService: GuiService,
-        private assetManager: AssetManagerService
+        private assetManager: AssetManagerService,
+        private saveGameService: SaveGameService
     ) { }
 
     async ngAfterViewInit(): Promise<void> {
@@ -39,6 +41,11 @@ export class ViewportComponent implements AfterViewInit, OnDestroy {
         if (this.resizeListener) {
             window.removeEventListener('resize', this.resizeListener);
             this.resizeListener = null;
+        }
+
+        const scene = this.sceneManager.getCurrentScene();
+        if (scene) {
+            this.saveGameService.save(scene);
         }
 
         // Clean up Babylon.js resources

--- a/src/app/engine/core/save-game.service.ts
+++ b/src/app/engine/core/save-game.service.ts
@@ -1,0 +1,75 @@
+// src/app/engine/core/save-game.service.ts
+import { Injectable } from '@angular/core';
+import { Scene } from '@babylonjs/core/scene';
+import { Vector3 } from '@babylonjs/core/Maths/math.vector';
+import { TimeService } from '../physics/time.service';
+
+export interface EntityState {
+    id: string;
+    position: { x: number; y: number; z: number };
+    velocity?: { x: number; y: number; z: number };
+}
+
+export interface SaveGameData {
+    timeElapsed: number;
+    timeOfDay: number;
+    entities: EntityState[];
+}
+
+@Injectable({ providedIn: 'root' })
+export class SaveGameService {
+    private storageKey = 'clearview-save';
+
+    constructor(private timeService: TimeService) {}
+
+    createSaveData(scene: Scene): SaveGameData {
+        const entities: EntityState[] = scene.meshes
+            .filter(m => !!m.physicsImpostor)
+            .map(m => {
+                const vel = m.physicsImpostor?.getLinearVelocity() || Vector3.Zero();
+                return {
+                    id: m.name,
+                    position: { x: m.position.x, y: m.position.y, z: m.position.z },
+                    velocity: { x: vel.x, y: vel.y, z: vel.z }
+                } as EntityState;
+            });
+
+        return {
+            timeElapsed: this.timeService.getElapsed(),
+            timeOfDay: this.timeService.getWorldTime(),
+            entities
+        };
+    }
+
+    save(scene: Scene): void {
+        const data = this.createSaveData(scene);
+        localStorage.setItem(this.storageKey, JSON.stringify(data));
+    }
+
+    load(scene: Scene): void {
+        const raw = localStorage.getItem(this.storageKey);
+        if (!raw) return;
+        const data = JSON.parse(raw) as SaveGameData;
+
+        this.timeService.setElapsed(data.timeElapsed);
+        this.timeService.setWorldTime(data.timeOfDay);
+
+        data.entities.forEach(ent => {
+            const mesh = scene.getMeshByName(ent.id);
+            if (mesh) {
+                mesh.position.set(ent.position.x, ent.position.y, ent.position.z);
+                if (mesh.physicsImpostor && ent.velocity) {
+                    mesh.physicsImpostor.setLinearVelocity(new Vector3(ent.velocity.x, ent.velocity.y, ent.velocity.z));
+                }
+            }
+        });
+    }
+
+    hasSave(): boolean {
+        return localStorage.getItem(this.storageKey) !== null;
+    }
+
+    clear(): void {
+        localStorage.removeItem(this.storageKey);
+    }
+}

--- a/src/app/engine/core/scene-manager.service.ts
+++ b/src/app/engine/core/scene-manager.service.ts
@@ -92,6 +92,11 @@ export class SceneManagerService {
             this.currentSceneInstance.dispose();
             this.currentSceneInstance = null;
         }
+
+        // Ensure the engine itself is fully cleaned up
+        if (this.engineService.hasValidEngine()) {
+            this.engineService.cleanUp();
+        }
     }
 
     getCurrentScene(): Scene | undefined {

--- a/src/app/engine/physics/time.service.ts
+++ b/src/app/engine/physics/time.service.ts
@@ -78,4 +78,11 @@ export class TimeService {
         this.startTime = performance.now() - (this.elapsed * 1000);
         this.continuousRotation = this.elapsed * this.starRotationFactor;
     }
+
+    // Restore elapsed time directly (used when loading save games)
+    setElapsed(seconds: number): void {
+        this.elapsed = seconds;
+        this.startTime = performance.now() - (seconds * 1000);
+        this.continuousRotation = this.elapsed * this.starRotationFactor;
+    }
 }

--- a/src/app/engine/scenes/scene001.scene.ts
+++ b/src/app/engine/scenes/scene001.scene.ts
@@ -21,6 +21,7 @@ import { MathUtils } from '../utils/math-utils.service';
 import { GroundMesh } from '@babylonjs/core';
 import { StandardMaterial } from '@babylonjs/core/Materials/standardMaterial';
 import { PhysicsImpostor } from '@babylonjs/core/Physics/physicsImpostor';
+import { SaveGameService } from '../core/save-game.service';
 
 // Import shader code
 import { vertexShader as skyVertexShader } from '../shaders/enhancedSky.vertex';
@@ -46,6 +47,7 @@ export class Scene001 extends BaseScene {
         // private mathUtils: MathUtils,
         private physicsService: PhysicsService,
         private playerService: PlayerService,
+        private saveGameService: SaveGameService,
     ) {
         super(engineService);
     }
@@ -73,7 +75,12 @@ export class Scene001 extends BaseScene {
         this.setupSky();
 
         // Intialize player (after terrain is ready)
-        this.playerService.init(this.scene); 
+        this.playerService.init(this.scene);
+
+        // Load saved state if available
+        if (this.saveGameService.hasSave()) {
+            this.saveGameService.load(this.scene);
+        }
 
         return this.scene;
     }

--- a/src/app/pages/demo/clearview/clearview.component.ts
+++ b/src/app/pages/demo/clearview/clearview.component.ts
@@ -1,5 +1,5 @@
 // src/app/pages/demo/clearview/clearview.component.ts
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { ViewportComponent } from '../../../components/clearview/viewport/viewport.component';
 import { MainMenuComponent } from '../../../components/ui/main-menu/main-menu.component';
 import { SettingsDialogComponent } from '../../../components/ui/settings-dialog/settings-dialog.component';
@@ -12,17 +12,22 @@ import { CommonModule } from '@angular/common';
     templateUrl: './clearview.component.html',
     styleUrls: ['./clearview.component.less']
 })
-export class ClearviewComponent implements OnInit {
+export class ClearviewComponent implements OnInit, OnDestroy {
     showGame = false;
 
     constructor(private ui: UiStateService) { }
 
     ngOnInit(): void {
+        document.body.classList.add('demo-dark');
         this.ui.mainMenuVisible$.subscribe(visible => {
             if (visible) {
                 this.showGame = false;
             }
         });
+    }
+
+    ngOnDestroy(): void {
+        document.body.classList.remove('demo-dark');
     }
 
     startGame(): void {

--- a/src/styles.less
+++ b/src/styles.less
@@ -73,6 +73,12 @@ body {
     overflow-y: hidden;
 }
 
+body.demo-dark {
+    background: linear-gradient(#2b2b2b, #000);
+    animation: none;
+    color: @text-light;
+}
+
 @keyframes gradientMove {
     0% {
         background-position: 0% 50%;


### PR DESCRIPTION
## Summary
- create SaveGameService to persist entities and time state
- allow TimeService to restore elapsed time
- load saved data when Scene001 starts
- save current scene when viewport component is destroyed

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6862b47476788322acd1330eb761e0c2