### PR TITLE
Add basic water system with buoyancy

### DIFF
--- a/src/app/engine/physics/physics.service.ts
+++ b/src/app/engine/physics/physics.service.ts
@@ -5,9 +5,22 @@ import * as CANNON from 'cannon-es';
 import { Vector3 } from '@babylonjs/core/Maths/math.vector';
 import { CannonJSPlugin } from '@babylonjs/core/Physics/Plugins/cannonJSPlugin';
 import { AbstractMesh, PhysicsImpostor, GroundMesh } from '@babylonjs/core';
+import { TimeService } from './time.service';
+import { WaterService } from '../world/water.service';
+import { MemoryUtilsService } from '../utils/memory-utils.service';
 
 @Injectable({ providedIn: 'root' })
 export class PhysicsService {
+    private _floatables: { mesh: AbstractMesh; volume: number; density: number }[] = [];
+    private _tempForce: Vector3 = new Vector3();
+    private _frame = 0;
+
+    constructor(
+        private timeService: TimeService,
+        private waterService: WaterService,
+        private memoryUtils: MemoryUtilsService
+    ) { }
+
     // Use an arrow function to ensure 'this' context is always correct
     enablePhysics = async (scene: Scene): Promise<void> => {
         const gravity = new Vector3(0, -9.81, 0);
@@ -25,5 +38,32 @@ export class PhysicsService {
             options,
             mesh.getScene()
         );
+    }
+
+    registerFloatable(mesh: AbstractMesh, volume: number, density: number): void {
+        this._floatables.push({ mesh, volume, density });
+    }
+
+    update(deltaTime: number): void {
+        if (this.timeService.isPaused()) return;
+        this._frame++;
+        if (this._frame % 3 !== 0) return;
+        this._updateBuoyancy(deltaTime);
+    }
+
+    private _updateBuoyancy(_deltaTime: number): void {
+        for (const f of this._floatables) {
+            const pos = f.mesh.getAbsolutePosition();
+            const tempPos = this.memoryUtils.getTempVector3();
+            tempPos.copyFrom(pos);
+            const height = this.waterService.getWaterHeightAt(tempPos);
+            if (pos.y < height) {
+                const depth = height - pos.y;
+                const submerged = Math.min(depth / (f.mesh.getBoundingInfo().boundingBox.extendSize.y * 2), 1);
+                const buoyancy = 9.81 * f.volume * (1 - f.density) * submerged;
+                this._tempForce.set(0, buoyancy, 0);
+                f.mesh.physicsImpostor?.applyForce(this._tempForce, pos);
+            }
+        }
     }
 }

--- a/src/app/engine/scenes/scene001.scene.ts
+++ b/src/app/engine/scenes/scene001.scene.ts
@@ -10,6 +10,7 @@ import { CameraService } from '../player/camera.service';
 import { LightService } from '../world/light.service';
 import { TerrainService } from '../world/terrain.service';
 import { PhysicsService } from '../physics/physics.service';
+import { WaterService } from '../world/water.service';
 import { PlayerService } from '../player/player.service';
 import { MaterialService } from '../material/material.service';
 import { SkyService } from '../world/sky.service';
@@ -46,6 +47,7 @@ export class Scene001 extends BaseScene {
         // private mathUtils: MathUtils,
         private physicsService: PhysicsService,
         private playerService: PlayerService,
+        private waterService: WaterService,
     ) {
         super(engineService);
     }
@@ -69,6 +71,9 @@ export class Scene001 extends BaseScene {
 
         // Set up scene elements that need assets
         await this.setupTerrain();
+        const waterPlane = MeshBuilder.CreateGround('water', { width: 200, height: 200 }, this.scene);
+        waterPlane.position = new Vector3(0, 0, 0);
+        this.waterService.createWater({ mesh: waterPlane, level: 0 });
 
         this.setupSky();
 
@@ -133,6 +138,7 @@ export class Scene001 extends BaseScene {
             testBox.material = new StandardMaterial('testBoxMat', this.scene);
             this.physicsService.addImpostor(testBox, PhysicsImpostor.BoxImpostor, { mass: 1, friction: 0.5 });
             console.log('Test box impostor:', testBox.physicsImpostor?.type);
+            this.physicsService.registerFloatable(testBox, 64, 0.6);
 
             // Heightmap terrain as before
             const ground = this.terrainService.createHeightMap(this.scene, {
@@ -175,6 +181,7 @@ export class Scene001 extends BaseScene {
         this.lightService.update();
         this.skyService.update();
         this.atmosphereService.update(this.scene);
+        this.physicsService.update(deltaTime);
     }
 
     dispose(): void {

--- a/src/app/engine/shaders/water.fragment.ts
+++ b/src/app/engine/shaders/water.fragment.ts
@@ -1,0 +1,13 @@
+export const fragmentShader = `
+precision highp float;
+varying vec2 vUV;
+varying float vWave;
+uniform vec3 waterColor;
+uniform vec3 foamColor;
+uniform float foamThreshold;
+uniform float lod;
+void main() {
+    float foam = smoothstep(foamThreshold - 0.01, foamThreshold + 0.01, abs(vWave));
+    vec3 color = mix(waterColor, foamColor, foam * (1.0 - lod));
+    gl_FragColor = vec4(color, 1.0);
+}`;

--- a/src/app/engine/shaders/water.vertex.ts
+++ b/src/app/engine/shaders/water.vertex.ts
@@ -1,0 +1,19 @@
+export const vertexShader = `
+precision highp float;
+attribute vec3 position;
+attribute vec2 uv;
+uniform mat4 worldViewProjection;
+uniform float time;
+uniform float amplitude;
+uniform float wavelength;
+uniform float speed;
+varying vec2 vUV;
+varying float vWave;
+void main() {
+    vUV = uv;
+    float wave = sin((position.x + position.z) / wavelength + time * speed) * amplitude;
+    vWave = wave;
+    vec3 pos = position;
+    pos.y += wave;
+    gl_Position = worldViewProjection * vec4(pos, 1.0);
+}`;

--- a/src/app/engine/utils/math-utils.service.spec.ts
+++ b/src/app/engine/utils/math-utils.service.spec.ts
@@ -1,13 +1,13 @@
 import { TestBed } from '@angular/core/testing';
 
-import { MathUtilsService } from './math-utils.service';
+import { MathUtils } from './math-utils.service';
 
 describe('MathUtilsService', () => {
-  let service: MathUtilsService;
+  let service: MathUtils;
 
   beforeEach(() => {
     TestBed.configureTestingModule({});
-    service = TestBed.inject(MathUtilsService);
+    service = TestBed.inject(MathUtils);
   });
 
   it('should be created', () => {

--- a/src/app/engine/utils/memory-utils.service.ts
+++ b/src/app/engine/utils/memory-utils.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core';
+import { Vector3, Color3 } from '@babylonjs/core/Maths/math';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class MemoryUtilsService {
+    private _tempVectorA = new Vector3();
+    private _tempVectorB = new Vector3();
+    private _tempColorA = new Color3();
+
+    getTempVector3(): Vector3 {
+        return this._tempVectorA;
+    }
+
+    getTempVector3B(): Vector3 {
+        return this._tempVectorB;
+    }
+
+    lerpColors(color1: Color3, color2: Color3, amount: number): Color3 {
+        Color3.LerpToRef(color1, color2, amount, this._tempColorA);
+        return this._tempColorA;
+    }
+}

--- a/src/app/engine/world/water-material.ts
+++ b/src/app/engine/world/water-material.ts
@@ -1,0 +1,40 @@
+import { ShaderMaterial, Color3, Scene } from '@babylonjs/core';
+import { vertexShader } from '../shaders/water.vertex';
+import { fragmentShader } from '../shaders/water.fragment';
+
+export interface WaterMaterialOptions {
+    waterColor?: Color3;
+    foamColor?: Color3;
+    amplitude?: number;
+    wavelength?: number;
+    speed?: number;
+    foamThreshold?: number;
+}
+
+export class WaterMaterial extends ShaderMaterial {
+    private _time = 0;
+
+    constructor(scene: Scene, options: WaterMaterialOptions = {}) {
+        super('waterMaterial', scene, {
+            vertexSource: vertexShader,
+            fragmentSource: fragmentShader
+        }, {
+            attributes: ['position', 'uv'],
+            uniforms: ['worldViewProjection', 'time', 'amplitude', 'wavelength', 'speed', 'foamThreshold', 'lod', 'waterColor', 'foamColor'],
+            needAlphaBlending: false
+        });
+
+        this.setColor3('waterColor', options.waterColor ?? new Color3(0.1, 0.4, 0.6));
+        this.setColor3('foamColor', options.foamColor ?? new Color3(1, 1, 1));
+        this.setFloat('amplitude', options.amplitude ?? 0.2);
+        this.setFloat('wavelength', options.wavelength ?? 4.0);
+        this.setFloat('speed', options.speed ?? 1.0);
+        this.setFloat('foamThreshold', options.foamThreshold ?? 0.2);
+        this.setFloat('lod', 0);
+
+        scene.onBeforeRenderObservable.add(() => {
+            this._time += scene.getEngine().getDeltaTime() * 0.001;
+            this.setFloat('time', this._time);
+        });
+    }
+}

--- a/src/app/engine/world/water.service.ts
+++ b/src/app/engine/world/water.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@angular/core';
+import { AbstractMesh, Mesh } from '@babylonjs/core';
+import { Vector3 } from '@babylonjs/core/Maths/math.vector';
+import { Scene } from '@babylonjs/core/scene';
+import { WaterMaterial, WaterMaterialOptions } from './water-material';
+
+export interface WaterOptions extends WaterMaterialOptions {
+    mesh: Mesh;
+    level: number;
+}
+
+interface WaterMeshInfo {
+    mesh: Mesh;
+    level: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class WaterService {
+    private _waterMeshes: WaterMeshInfo[] = [];
+    private _tideOffset = 0;
+
+    createWater(options: WaterOptions): void {
+        const material = new WaterMaterial(options.mesh.getScene(), options);
+        options.mesh.material = material;
+        this._waterMeshes.push({ mesh: options.mesh, level: options.level });
+    }
+
+    getWaterHeightAt(pos: Vector3): number {
+        if (this._waterMeshes.length === 0) return -Infinity;
+        // Simple approach: assume single water level for now
+        return this._waterMeshes[0].level + this._tideOffset;
+    }
+
+    dispose(): void {
+        for (const info of this._waterMeshes) {
+            info.mesh.material?.dispose();
+        }
+        this._waterMeshes.length = 0;
+    }
+}


### PR DESCRIPTION
## Summary
- create `WaterService` and `WaterMaterial`
- add new water vertex and fragment shaders
- extend `PhysicsService` with floatable registry and buoyancy update
- provide a simple `MemoryUtilsService`
- integrate water into `Scene001` and update physics on each frame
- fix math-utils spec

## Testing
- `npm test` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_68638ab61b9883229d2a772f11faa064