### PR TITLE
Refine campfire particles

### DIFF
--- a/src/app/engine/scenes/scene001.scene.ts
+++ b/src/app/engine/scenes/scene001.scene.ts
@@ -6,7 +6,6 @@ import { MeshBuilder } from '@babylonjs/core/Meshes/meshBuilder';
 import { BaseScene } from '../base/scene';
 import { EngineService } from '../core/engine.service';
 import { TimeService } from '../physics/time.service';
-import { CameraService } from '../player/camera.service';
 import { LightService } from '../world/light.service';
 import { TerrainService } from '../world/terrain.service';
 import { PhysicsService } from '../physics/physics.service';
@@ -17,10 +16,10 @@ import { AtmosphereService } from '../world/atmosphere.service';
 import { CelestialService } from '../world/celestial.service';
 import { ShaderRegistryService } from '../shaders/shader-registry.service';
 import { AssetManagerService } from '../core/asset-manager.service';
-import { MathUtils } from '../utils/math-utils.service';
-import { Angle, Color3, Color4, GroundMesh, ParticleSystem, PointLight, Texture } from '@babylonjs/core';
-import { StandardMaterial } from '@babylonjs/core/Materials/standardMaterial';
+import { GroundMesh } from '@babylonjs/core';
 import { PhysicsImpostor } from '@babylonjs/core/Physics/physicsImpostor';
+import { Campfire } from '../world/campfire';
+import { StandardMaterial } from '@babylonjs/core/Materials/standardMaterial';
 
 // Import shader code
 import { vertexShader as skyVertexShader } from '../shaders/enhancedSky.vertex';
@@ -30,6 +29,7 @@ import { fragmentShader as skyFragmentShader } from '../shaders/enhancedSky.frag
 export class Scene001 extends BaseScene {
     // Asset paths
     private terrainPath = '/assets/materials/terrain/rocky-rugged-terrain_1/';
+    private campfires: Campfire[] = [];
 
     constructor(
         engineService: EngineService,
@@ -160,101 +160,9 @@ export class Scene001 extends BaseScene {
                 resolve();
             });
 
-            // Add campfire for testing
-            const fireHeight = 9.5;
-            // Log Material
-            const logMaterial = new StandardMaterial("logMat", this.scene);
-            logMaterial.diffuseColor = new Color3(0.81, 0.49, 0.16);
-            logMaterial.roughness = 1;
-            logMaterial.specularColor = Color3.Black();
-
-            // Logs - placed in equilateral triangle layout
-            const R = 0.05;
-            const sqrt3over2 = Math.sqrt(3) / 2;
-            const tiltDeg = 70;
-
-            // Equilateral triangle vertices (logs) centered on (0, 0)
-            const logPositions = [
-                { x: 0, z: R },
-                { x: -sqrt3over2 * R, z: -0.5 * R },
-                { x: sqrt3over2 * R, z: -0.5 * R }
-            ];
-        
-            logPositions.forEach((pos, i) => {
-                const log = MeshBuilder.CreateCylinder(`log${i}`, { diameter: 0.05, height: 0.3 }, this.scene);
-                log.material = logMaterial;
-            
-                log.position.set(pos.x, fireHeight + 0.1, pos.z);
-            
-                // Make the log face the center
-                const angleToCenter = Math.atan2(-pos.x, -pos.z); // Y rotation
-                log.rotation.y = angleToCenter;
-            
-                // Lean inward
-                log.rotation.z = Angle.FromDegrees(tiltDeg).radians();
-            });
-        
-            // Fire Light (centered)
-            const fireLight = new PointLight("fireLight", new Vector3(0, fireHeight + 0.2, 0), this.scene);
-            fireLight.diffuse = new Color3(1.0, 0.5, 0.2);
-            fireLight.intensity = 2;
-            fireLight.range = 2;
-        
-            this.scene.onBeforeRenderObservable.add(() => {
-                const time = performance.now() * 0.002;
-                fireLight.intensity = 1.8 + Math.sin(time * 8) * 0.3 + Math.random() * 0.2;
-            });
-        
-            // Fire Particles
-            const fire = new ParticleSystem("fire", 100, this.scene);
-            fire.particleTexture = new Texture("https://playground.babylonjs.com/textures/flare.png", this.scene);
-            fire.emitter = new Vector3(0, fireHeight + 0.13, 0);
-            fire.minEmitBox = new Vector3(-0.05, 0, -0.05);
-            fire.maxEmitBox = new Vector3(0.05, 0, 0.05);
-            fire.color1 = new Color4(1, 0.77, 0, 0.4);
-            fire.color2 = new Color4(1, 0.3, 0, 0.3);
-            fire.colorDead = new Color4(0.2, 0, 0, 0.0);
-            fire.minSize = 0.07;
-            fire.maxSize = 0.15;
-            fire.minLifeTime = 0.3;
-            fire.maxLifeTime = 0.8;
-            fire.emitRate = 80;
-            fire.blendMode = ParticleSystem.BLENDMODE_ONEONE;
-            fire.direction1 = new Vector3(0, 0.5, 0);
-            fire.direction2 = new Vector3(0, 0.8, 0);
-            fire.gravity = new Vector3(0, 0, 0);
-            fire.minAngularSpeed = 0;
-            fire.maxAngularSpeed = Math.PI;
-            fire.minEmitPower = 0.4;
-            fire.maxEmitPower = 0.6;
-            fire.updateSpeed = 0.01;
-            fire.start();
-        
-            // Smoke Particles
-            const smoke = new ParticleSystem("smoke", 50, this.scene);
-            smoke.particleTexture = new Texture("https://playground.babylonjs.com/textures/flare.png", this.scene);
-            smoke.particleTexture.hasAlpha = true;
-            smoke.emitter = new Vector3(0, fireHeight + 0.2, 0);
-            smoke.minEmitBox = new Vector3(-0.03, 0, -0.03);
-            smoke.maxEmitBox = new Vector3(0.03, 0, 0.03);
-            smoke.color1 = new Color4(0.2, 0.2, 0.2, 0.1);
-            smoke.color2 = new Color4(0.1, 0.1, 0.1, 0.06);
-            smoke.colorDead = new Color4(0, 0, 0, 0.0);
-            smoke.minSize = 0.08;
-            smoke.maxSize = 0.15;
-            smoke.minLifeTime = 1;
-            smoke.maxLifeTime = 2.5;
-            smoke.emitRate = 100;
-            smoke.blendMode = ParticleSystem.BLENDMODE_ONEONE;
-            smoke.direction1 = new Vector3(-0.05, 0.9, -0.05);
-            smoke.direction2 = new Vector3(0.05, 1.1, 0.05);
-            smoke.gravity = new Vector3(0, 0, 0);
-            smoke.minAngularSpeed = 0;
-            smoke.maxAngularSpeed = 0.3;
-            smoke.minEmitPower = 0.2;
-            smoke.maxEmitPower = 0.4;
-            smoke.updateSpeed = 0.01;
-            smoke.start();
+            // Create a test campfire
+            const campfire = new Campfire(this.scene, new Vector3(0, 9.5, 0), this.timeService);
+            this.campfires.push(campfire);
         });
     }
 
@@ -275,6 +183,9 @@ export class Scene001 extends BaseScene {
 
     dispose(): void {
         if (this.scene) {
+            this.campfires.forEach(f => f.dispose());
+            this.campfires = [];
+
             // Let the AssetManager know we're disposing this scene
             this.assetManager.handleSceneDisposal(this.scene);
             this.scene.dispose();

--- a/src/app/engine/world/campfire.ts
+++ b/src/app/engine/world/campfire.ts
@@ -1,0 +1,162 @@
+// src/app/engine/world/campfire.ts
+import { Scene } from '@babylonjs/core/scene';
+import { TransformNode } from '@babylonjs/core/Meshes/transformNode';
+import { MeshBuilder, Mesh } from '@babylonjs/core/Meshes';
+import { PointLight } from '@babylonjs/core/Lights/pointLight';
+import { ParticleSystem } from '@babylonjs/core/Particles/particleSystem';
+import { Texture } from '@babylonjs/core/Materials/Textures/texture';
+import { StandardMaterial } from '@babylonjs/core/Materials/standardMaterial';
+import { Color3, Color4 } from '@babylonjs/core/Maths/math.color';
+import { Vector3 } from '@babylonjs/core/Maths/math.vector';
+import { TimeService } from '../physics/time.service';
+
+export class Campfire {
+    private static sharedTexture: Texture | null = null;
+    private static readonly FIRE_TEXTURE_URL = 'https://playground.babylonjs.com/textures/flare.png';
+    private static readonly FIRE_MIN_EMIT_BOX = new Vector3(-0.05, 0.15, -0.05);
+    private static readonly FIRE_MAX_EMIT_BOX = new Vector3(0.05, 0.15, 0.05);
+    private static readonly SMOKE_MIN_EMIT_BOX = new Vector3(-0.03, 0.22, -0.03);
+    private static readonly SMOKE_MAX_EMIT_BOX = new Vector3(0.03, 0.22, 0.03);
+    private static readonly FIRE_DIRECTION1 = new Vector3(0, 0.5, 0);
+    private static readonly FIRE_DIRECTION2 = new Vector3(0, 0.8, 0);
+    private static readonly SMOKE_DIRECTION1 = new Vector3(-0.05, 0.9, -0.05);
+    private static readonly SMOKE_DIRECTION2 = new Vector3(0.05, 1.1, 0.05);
+    private static readonly ZERO_GRAVITY = new Vector3(0, 0, 0);
+
+    private root: TransformNode;
+    private logs: Mesh[] = [];
+    private fireLight!: PointLight;
+    private fire!: ParticleSystem;
+    private smoke!: ParticleSystem;
+
+    private readonly fireSpeed = 0.01;
+    private readonly smokeSpeed = 0.01;
+
+    constructor(private scene: Scene, position: Vector3, private timeService: TimeService) {
+        this.root = new TransformNode('campfireRoot', scene);
+        this.root.position.copyFrom(position);
+
+        this.createLogs();
+        this.createLight();
+        this.createParticles();
+
+        this.scene.onBeforeRenderObservable.add(() => this.update());
+    }
+
+    private createLogs(): void {
+        const logMaterial = new StandardMaterial('logMat', this.scene);
+        logMaterial.diffuseColor = new Color3(0.81, 0.49, 0.16);
+        logMaterial.roughness = 1;
+        logMaterial.specularColor = Color3.Black();
+
+        const R = 0.05;
+        const sqrt3over2 = Math.sqrt(3) / 2;
+        const tiltDeg = 70;
+
+        const logPositions = [
+            { x: 0, z: R },
+            { x: -sqrt3over2 * R, z: -0.5 * R },
+            { x: sqrt3over2 * R, z: -0.5 * R }
+        ];
+
+        logPositions.forEach((pos, i) => {
+            const log = MeshBuilder.CreateCylinder(`log${i}`, { diameter: 0.05, height: 0.3 }, this.scene);
+            log.material = logMaterial;
+            log.position.set(pos.x, 0.1, pos.z);
+            log.parent = this.root;
+
+            const angleToCenter = Math.atan2(-pos.x, -pos.z);
+            log.rotation.y = angleToCenter;
+            log.rotation.z = tiltDeg * Math.PI / 180;
+            this.logs.push(log);
+        });
+    }
+
+    private createLight(): void {
+        this.fireLight = new PointLight('fireLight', new Vector3(0, 0.2, 0), this.scene);
+        this.fireLight.diffuse = new Color3(1.0, 0.5, 0.2);
+        this.fireLight.intensity = 2;
+        this.fireLight.range = 2;
+        this.fireLight.parent = this.root;
+    }
+
+    private createParticles(): void {
+        this.fire = new ParticleSystem('fire', 100, this.scene);
+        if (!Campfire.sharedTexture) {
+            Campfire.sharedTexture = new Texture(Campfire.FIRE_TEXTURE_URL, this.scene);
+        }
+        this.fire.particleTexture = Campfire.sharedTexture;
+        this.fire.emitter = this.root as any;
+        this.fire.minEmitBox = Campfire.FIRE_MIN_EMIT_BOX;
+        this.fire.maxEmitBox = Campfire.FIRE_MAX_EMIT_BOX;
+        this.fire.color1 = new Color4(1, 0.77, 0, 0.4);
+        this.fire.color2 = new Color4(1, 0.3, 0, 0.3);
+        this.fire.colorDead = new Color4(0.2, 0, 0, 0.0);
+        this.fire.minSize = 0.07;
+        this.fire.maxSize = 0.15;
+        this.fire.minLifeTime = 0.3;
+        this.fire.maxLifeTime = 0.8;
+        this.fire.emitRate = 80;
+        this.fire.blendMode = ParticleSystem.BLENDMODE_ONEONE;
+        this.fire.direction1 = Campfire.FIRE_DIRECTION1;
+        this.fire.direction2 = Campfire.FIRE_DIRECTION2;
+        this.fire.gravity = Campfire.ZERO_GRAVITY;
+        this.fire.minAngularSpeed = 0;
+        this.fire.maxAngularSpeed = Math.PI;
+        this.fire.minEmitPower = 0.4;
+        this.fire.maxEmitPower = 0.6;
+        this.fire.updateSpeed = this.fireSpeed;
+        this.fire.start();
+
+        this.smoke = new ParticleSystem('smoke', 50, this.scene);
+        this.smoke.particleTexture = Campfire.sharedTexture!;
+        this.smoke.particleTexture.hasAlpha = true;
+        this.smoke.emitter = this.root as any;
+        this.smoke.minEmitBox = Campfire.SMOKE_MIN_EMIT_BOX;
+        this.smoke.maxEmitBox = Campfire.SMOKE_MAX_EMIT_BOX;
+        this.smoke.color1 = new Color4(0.2, 0.2, 0.2, 0.1);
+        this.smoke.color2 = new Color4(0.1, 0.1, 0.1, 0.06);
+        this.smoke.colorDead = new Color4(0, 0, 0, 0.0);
+        this.smoke.minSize = 0.08;
+        this.smoke.maxSize = 0.15;
+        this.smoke.minLifeTime = 1;
+        this.smoke.maxLifeTime = 2.5;
+        this.smoke.emitRate = 100;
+        this.smoke.blendMode = ParticleSystem.BLENDMODE_ONEONE;
+        this.smoke.direction1 = Campfire.SMOKE_DIRECTION1;
+        this.smoke.direction2 = Campfire.SMOKE_DIRECTION2;
+        this.smoke.gravity = Campfire.ZERO_GRAVITY;
+        this.smoke.minAngularSpeed = 0;
+        this.smoke.maxAngularSpeed = 0.3;
+        this.smoke.minEmitPower = 0.2;
+        this.smoke.maxEmitPower = 0.4;
+        this.smoke.updateSpeed = this.smokeSpeed;
+        this.smoke.start();
+    }
+
+    private update(): void {
+        if (this.timeService.isPaused()) {
+            this.fire.updateSpeed = 0;
+            this.smoke.updateSpeed = 0;
+            return;
+        }
+
+        this.fire.updateSpeed = this.fireSpeed;
+        this.smoke.updateSpeed = this.smokeSpeed;
+
+        const t = this.timeService.getElapsed();
+        this.fireLight.intensity = 1.8 + Math.sin(t * 8) * 0.3 + Math.random() * 0.2;
+    }
+
+    setPosition(position: Vector3): void {
+        this.root.position.copyFrom(position);
+    }
+
+    dispose(): void {
+        this.fire.dispose();
+        this.smoke.dispose();
+        this.fireLight.dispose();
+        this.logs.forEach(log => log.dispose());
+        this.root.dispose();
+    }
+}


### PR DESCRIPTION
## Summary
- tweak campfire emitters 15cm higher
- reuse a single flare texture for smoke and fire
- store constant vectors to reduce allocations

## Testing
- `npx tsc -p tsconfig.app.json --noEmit`
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6863f5485cb083229c91b7cca77ce1bf