### PR TITLE
Add basic performance monitoring

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -6,12 +6,16 @@ import { provideZoneChangeDetection } from '@angular/core';
 import { routes } from './app.routes';
 import { Scene001 } from './engine/scenes/scene001.scene';
 import { MathUtils } from './engine/utils/math-utils.service';
+import { PerformanceSettingsService } from './engine/performance/performance-settings.service';
+import { PerformanceService } from './engine/performance/performance.service';
 
 export const appConfig: ApplicationConfig = {
   providers: [
-    provideZoneChangeDetection({ eventCoalescing: true }), 
-    provideRouter(routes), 
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    provideRouter(routes),
     Scene001,
-    MathUtils
+    MathUtils,
+    PerformanceSettingsService,
+    PerformanceService
   ]
 };

--- a/src/app/components/clearview/viewport/viewport.component.html
+++ b/src/app/components/clearview/viewport/viewport.component.html
@@ -3,4 +3,5 @@
     <canvas #renderCanvas class="render-canvas"></canvas>
     <app-loading-indicator></app-loading-indicator>
     <app-pause-menu></app-pause-menu>
+    <app-fps-counter *ngIf="showFps"></app-fps-counter>
 </div>

--- a/src/app/components/clearview/viewport/viewport.component.ts
+++ b/src/app/components/clearview/viewport/viewport.component.ts
@@ -8,11 +8,18 @@ import { GuiService } from '../../../engine/core/gui.service';
 import { AssetManagerService } from '../../../engine/core/asset-manager.service';
 import { PauseMenuComponent } from '../../ui/pause-menu/pause-menu.component';
 import { LoadingIndicatorComponent } from '../../ui/loading-indicator/loading-indicator.component';
+import { FpsCounterComponent } from '../../ui/fps-counter/fps-counter.component';
+import { PerformanceSettingsService } from '../../../engine/performance/performance-settings.service';
 
 @Component({
     selector: 'clearview-viewport',
     standalone: true,
-    imports: [CommonModule, PauseMenuComponent, LoadingIndicatorComponent],
+    imports: [
+        CommonModule,
+        PauseMenuComponent,
+        LoadingIndicatorComponent,
+        FpsCounterComponent
+    ],
     templateUrl: './viewport.component.html',
     styleUrls: ['./viewport.component.less']
 })
@@ -20,13 +27,18 @@ export class ViewportComponent implements AfterViewInit, OnDestroy {
     @ViewChild('renderCanvas', { static: true }) canvasRef!: ElementRef<HTMLCanvasElement>;
     private resizeListener: (() => void) | null = null;
 
+    showFps = true;
+
     constructor(
         private ngZone: NgZone,
         private engineService: EngineService,
         private sceneManager: SceneManagerService,
         private guiService: GuiService,
-        private assetManager: AssetManagerService
-    ) { }
+        private assetManager: AssetManagerService,
+        private perfSettings: PerformanceSettingsService
+    ) {
+        this.perfSettings.settings$.subscribe(s => this.showFps = s.showFps);
+    }
 
     async ngAfterViewInit(): Promise<void> {
         this.ngZone.runOutsideAngular(async () => {

--- a/src/app/components/ui/fps-counter/fps-counter.component.html
+++ b/src/app/components/ui/fps-counter/fps-counter.component.html
@@ -1,0 +1,1 @@
+<div class="fps-counter">{{fps}} fps</div>

--- a/src/app/components/ui/fps-counter/fps-counter.component.less
+++ b/src/app/components/ui/fps-counter/fps-counter.component.less
@@ -1,0 +1,11 @@
+.fps-counter {
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  padding: 2px 6px;
+  background: rgba(0,0,0,0.5);
+  color: #0f0;
+  font-family: monospace;
+  font-size: 12px;
+  pointer-events: none;
+}

--- a/src/app/components/ui/fps-counter/fps-counter.component.ts
+++ b/src/app/components/ui/fps-counter/fps-counter.component.ts
@@ -1,0 +1,26 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Subscription } from 'rxjs';
+import { PerformanceService } from '../../../engine/performance/performance.service';
+
+@Component({
+  selector: 'app-fps-counter',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './fps-counter.component.html',
+  styleUrls: ['./fps-counter.component.less']
+})
+export class FpsCounterComponent implements OnInit, OnDestroy {
+  fps = 0;
+  private sub?: Subscription;
+
+  constructor(private perf: PerformanceService) {}
+
+  ngOnInit(): void {
+    this.sub = this.perf.fps$.subscribe(v => this.fps = v);
+  }
+
+  ngOnDestroy(): void {
+    this.sub?.unsubscribe();
+  }
+}

--- a/src/app/components/ui/settings-dialog/settings-dialog.component.html
+++ b/src/app/components/ui/settings-dialog/settings-dialog.component.html
@@ -4,7 +4,18 @@
         <div id="contain">
             <h2 class="title">Settings</h2>
             <div class="menu-content">
-                <p>Configure your experience.</p>
+                <label>
+                    Quality
+                    <select [(ngModel)]="settings.quality">
+                        <option value="low">Low</option>
+                        <option value="medium">Medium</option>
+                        <option value="high">High</option>
+                    </select>
+                </label>
+                <label>
+                    <input type="checkbox" [(ngModel)]="settings.showFps" /> Show FPS
+                </label>
+                <button class="btn-parchment" (click)="save()">Save</button>
                 <button class="btn-parchment" (click)="close()">Close</button>
             </div>
         </div>

--- a/src/app/components/ui/settings-dialog/settings-dialog.component.ts
+++ b/src/app/components/ui/settings-dialog/settings-dialog.component.ts
@@ -1,23 +1,30 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { Subscription } from 'rxjs';
 import { UiStateService } from '../../../services/ui-state.service';
+import { PerformanceSettingsService, PerformanceSettings } from '../../../engine/performance/performance-settings.service';
 
 @Component({
     selector: 'app-settings-dialog',
     standalone: true,
-    imports: [CommonModule],
+    imports: [CommonModule, FormsModule],
     templateUrl: './settings-dialog.component.html',
     styleUrls: ['./settings-dialog.component.less']
 })
 export class SettingsDialogComponent implements OnInit, OnDestroy {
     isVisible = false;
     private sub?: Subscription;
+    settings!: PerformanceSettings;
 
-    constructor(private ui: UiStateService) {}
+    constructor(
+        private ui: UiStateService,
+        private perfSettings: PerformanceSettingsService
+    ) {}
 
     ngOnInit(): void {
         this.sub = this.ui.settingsVisible$.subscribe(v => this.isVisible = v);
+        this.settings = this.perfSettings.getSettings();
     }
 
     ngOnDestroy(): void {
@@ -26,5 +33,10 @@ export class SettingsDialogComponent implements OnInit, OnDestroy {
 
     close(): void {
         this.ui.hideSettings();
+    }
+
+    save(): void {
+        this.perfSettings.update(this.settings);
+        this.close();
     }
 }

--- a/src/app/engine/core/scene-manager.service.ts
+++ b/src/app/engine/core/scene-manager.service.ts
@@ -5,6 +5,7 @@ import { BaseScene } from '../base/scene';
 import { EngineService } from './engine.service';
 import { Observable } from 'rxjs';
 import { AssetManagerService } from '../core/asset-manager.service';
+import { PerformanceService } from '../performance/performance.service';
 
 @Injectable({ providedIn: 'root' })
 export class SceneManagerService {
@@ -14,7 +15,8 @@ export class SceneManagerService {
     constructor(
         private engineService: EngineService,
         private assetManager: AssetManagerService,
-        private injector: Injector
+        private injector: Injector,
+        private perfService: PerformanceService
     ) { }
 
     async loadScene(sceneType: Type<BaseScene>, canvas: HTMLCanvasElement): Promise<void> {
@@ -23,6 +25,7 @@ export class SceneManagerService {
 
         // Create a fresh engine with the new canvas
         const engine = this.engineService.createEngine(canvas);
+        this.perfService.initialize(engine);
 
         // Get scene instance from Angular DI system
         this.currentSceneInstance = this.injector.get(sceneType);
@@ -49,6 +52,7 @@ export class SceneManagerService {
         this.renderLoopActive = true;
 
         engine.runRenderLoop(() => {
+            this.perfService.beginFrame();
             if (this.currentSceneInstance) {
                 const delta = engine.getDeltaTime();
                 this.currentSceneInstance.update(delta);
@@ -57,6 +61,7 @@ export class SceneManagerService {
                     scene.render();
                 }
             }
+            this.perfService.endFrame();
         });
     }
 

--- a/src/app/engine/performance/performance-settings.service.spec.ts
+++ b/src/app/engine/performance/performance-settings.service.spec.ts
@@ -1,0 +1,20 @@
+import { TestBed } from '@angular/core/testing';
+import { PerformanceSettingsService } from './performance-settings.service';
+
+describe('PerformanceSettingsService', () => {
+  let service: PerformanceSettingsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(PerformanceSettingsService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should update settings', () => {
+    service.update({ quality: 'low' });
+    expect(service.getSettings().quality).toBe('low');
+  });
+});

--- a/src/app/engine/performance/performance-settings.service.ts
+++ b/src/app/engine/performance/performance-settings.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+
+export interface PerformanceSettings {
+  quality: 'low' | 'medium' | 'high';
+  showFps: boolean;
+}
+
+@Injectable({ providedIn: 'root' })
+export class PerformanceSettingsService {
+  private settings: PerformanceSettings = { quality: 'high', showFps: true };
+  private subject = new BehaviorSubject<PerformanceSettings>(this.settings);
+
+  constructor() {
+    const saved = localStorage.getItem('performanceSettings');
+    if (saved) {
+      this.settings = { ...this.settings, ...JSON.parse(saved) };
+      this.subject.next(this.settings);
+    }
+  }
+
+  get settings$(): Observable<PerformanceSettings> {
+    return this.subject.asObservable();
+  }
+
+  getSettings(): PerformanceSettings {
+    return this.settings;
+  }
+
+  update(partial: Partial<PerformanceSettings>): void {
+    this.settings = { ...this.settings, ...partial };
+    localStorage.setItem('performanceSettings', JSON.stringify(this.settings));
+    this.subject.next(this.settings);
+  }
+}

--- a/src/app/engine/performance/performance.benchmark.spec.ts
+++ b/src/app/engine/performance/performance.benchmark.spec.ts
@@ -1,0 +1,15 @@
+import { TimeService } from '../physics/time.service';
+
+describe('Performance Benchmarks', () => {
+  it('TimeService.update should be performant', () => {
+    const service = new TimeService();
+    const iterations = 1000;
+    const start = performance.now();
+    for (let i = 0; i < iterations; i++) {
+      service.update(16);
+    }
+    const duration = performance.now() - start;
+    // Expect average below 0.1ms
+    expect(duration).toBeLessThan(100);
+  });
+});

--- a/src/app/engine/performance/performance.service.spec.ts
+++ b/src/app/engine/performance/performance.service.spec.ts
@@ -1,0 +1,23 @@
+import { TestBed } from '@angular/core/testing';
+import { PerformanceService } from './performance.service';
+
+describe('PerformanceService', () => {
+  let service: PerformanceService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(PerformanceService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should emit fps values', (done) => {
+    service['fpsSubject'].next(60);
+    service.fps$.subscribe(v => {
+      expect(v).toBe(60);
+      done();
+    });
+  });
+});

--- a/src/app/engine/performance/performance.service.ts
+++ b/src/app/engine/performance/performance.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { Engine } from '@babylonjs/core/Engines/engine';
+
+@Injectable({ providedIn: 'root' })
+export class PerformanceService {
+  private fpsSubject = new BehaviorSubject<number>(0);
+  private cpuFrameTimeSubject = new BehaviorSubject<number>(0);
+  private engine: Engine | null = null;
+  private frameStart = 0;
+
+  get fps$(): Observable<number> {
+    return this.fpsSubject.asObservable();
+  }
+
+  get cpuFrameTime$(): Observable<number> {
+    return this.cpuFrameTimeSubject.asObservable();
+  }
+
+  initialize(engine: Engine): void {
+    this.engine = engine;
+  }
+
+  beginFrame(): void {
+    this.frameStart = performance.now();
+  }
+
+  endFrame(): void {
+    const end = performance.now();
+    this.cpuFrameTimeSubject.next(end - this.frameStart);
+    if (this.engine) {
+      this.fpsSubject.next(Math.round(this.engine.getFps()));
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- create `PerformanceService` with FPS and CPU frame time monitoring
- add `PerformanceSettingsService` to store quality and FPS counter settings
- overlay FPS counter in the viewport
- expose settings form to change performance options
- instrument SceneManager to report frame metrics
- provide basic performance benchmark test

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68660fc1999483229009222304affdb0